### PR TITLE
Add support for chunked binary body processing

### DIFF
--- a/HTTPserver.cpp
+++ b/HTTPserver.cpp
@@ -263,7 +263,7 @@ void HTTPserver::handleNewline ()
     // a blank line on its own signals switching to the POST key/values or binary body
     case START_LINE:
       clearBuffers ();
-      newState (octetStream ? BODY : POST_NAME);
+      newState (binaryBody ? BODY : POST_NAME);
       break;
 
     // wrap up this POST key/value and start a new one
@@ -282,7 +282,7 @@ void HTTPserver::handleNewline ()
       if (strcasecmp (keyBuffer, "Content-Length") == 0)
         contentLength = atol (valueBuffer);
       if (strcasecmp (keyBuffer, "Content-Type") == 0 && strcasecmp (valueBuffer, "application/octet-stream") == 0)
-        octetStream = true;
+        binaryBody = true;
       clearBuffers ();
       newState (START_LINE);
       break;
@@ -537,7 +537,7 @@ void HTTPserver::begin (Print * output_)
   encodePhase = ENCODE_NONE;
   flags = FLAG_NONE;
   postRequest = false;
-  octetStream = false;
+  binaryBody = false;
   contentLength = 0;
   receivedLength = 0;
   sendBufferPos = 0;

--- a/HTTPserver.h
+++ b/HTTPserver.h
@@ -69,7 +69,6 @@ class HTTPserver : public Print
     };
 
     bool postRequest; // true if a POST type
-    bool octetStream; // true if "Content-Type" header is "application/octet-stream"
 
   private:
 
@@ -111,8 +110,11 @@ class HTTPserver : public Print
     unsigned long getContentLength () { return contentLength; }
     unsigned long getReceivedLength () { return receivedLength; }
 
-   // set to stop further processing (eg. on error)
+    // set to stop further processing (eg. on error)
     bool done;
+
+    // true if "Content-Type" header is "application/octet-stream" OR application can set for other relevant type(s)
+    bool binaryBody;
 
   protected:
 

--- a/HTTPserver.h
+++ b/HTTPserver.h
@@ -5,6 +5,7 @@ class HTTPserver : public Print
   protected:
   static const size_t MAX_KEY_LENGTH = 40;     // maximum size for a key
   static const size_t MAX_VALUE_LENGTH = 100;  // maximum size for a value
+  static const size_t BODY_CHUNK_LENGTH = 16;  // maximum size for a binary body chunk
   static const size_t SEND_BUFFER_LENGTH = 64; // how much to buffer sends
 
   private:
@@ -14,6 +15,9 @@ class HTTPserver : public Print
   char valueBuffer [MAX_VALUE_LENGTH + 1];     // store here
   size_t valueBufferPos;                       // how much data we have collected
 
+  byte bodyBuffer [BODY_CHUNK_LENGTH];      // store here
+  size_t bodyBufferPos;                     // how much data we have collected
+  
   char sendBuffer [SEND_BUFFER_LENGTH];     // for buffering output
   size_t sendBufferPos;                     // how much in buffer
 
@@ -37,6 +41,7 @@ class HTTPserver : public Print
     COOKIE_VALUE,       // eg. light
     POST_NAME,          // eg. action
     POST_VALUE,         // eg. add
+    BODY,               // eg. octet-stream binary blob
   };
   // current state
   StateType state;
@@ -64,6 +69,7 @@ class HTTPserver : public Print
     };
 
     bool postRequest; // true if a POST type
+    bool octetStream; // true if "Content-Type" header is "application/octet-stream"
 
   private:
 
@@ -80,6 +86,7 @@ class HTTPserver : public Print
   // buffer handlers
   void addToKeyBuffer (const byte inByte);
   void addToValueBuffer (byte inByte, const bool percentEncoded);
+  void addToBodyBuffer (const byte inByte);
   void clearBuffers ();
   // state handlers
   void handleNewline ();
@@ -99,6 +106,10 @@ class HTTPserver : public Print
 
     // empty sending buffer
     void flush ();  // for emptying send buffer
+    
+    // give application read access to expected/current content length
+    unsigned long getContentLength () { return contentLength; }
+    unsigned long getReceivedLength () { return receivedLength; }
 
    // set to stop further processing (eg. on error)
     bool done;
@@ -113,6 +124,7 @@ class HTTPserver : public Print
     virtual void processHeaderArgument  (const char * key, const char * value, const byte flags) { }
     virtual void processCookie          (const char * key, const char * value, const byte flags) { }
     virtual void processPostArgument    (const char * key, const char * value, const byte flags) { }
+    virtual void processBodyChunk       (const byte * data, const size_t length, const byte flags) { }
 
     // for outputting back to client
   	size_t write(uint8_t c);


### PR DESCRIPTION
This library was immensely helpful for me in the last couple of weeks. However, one of the things that I had to handle was a POST request submitted with "application/octet-stream" encoding. The library as-is treated this as key/value pairs in a POST body, which poses some problems:

- Any `=` characters found in the `POST_NAME` state are lost since they are treated as delineators
- Any `&` characters found in the `POST_NAME` or `POST_VALUE` state are lost for the same reason
- Content is limited to the key or value max buffer length, at which point a buffer overflow flag is set and further data is dropped
- The `processPostArgument` callback assumes an escaped, null-terminated string and provides no other way to determine content length (or whether data is in the "key" or "value" portion of the argument)

In the best case, you'd get a binary blob POSTed from the client which was less than the length of the max key buffer, contained no `=` or `&` or `NULL` bytes, and could be handled in `processPostArgument` by only working with the `key` data. As you can see, this is a terribly narrow set of conditions.

To fix this, I added a new `BODY` state which is entered if `Content-Type` is detected as `application/octet-stream`, and a small internal buffer (currently 16 bytes), and a new `processBodyChunk` callback which is called each time the buffer fills up and again at the end of the content, however much remains. This approach allows the library to retain its small RAM footprint while simultaneously allowing the application to process a potentially huge blob of data from a client. This works well in my own project, so I figured I'd send it back upstream.

For convenience, I also added accessors for the private `contentLength` and `receivedLength` members.